### PR TITLE
Rename DummyLinkStore to StatsDummyLinkStore

### DIFF
--- a/src/test/java/com/facebook/LinkBench/GraphStoreTestBase.java
+++ b/src/test/java/com/facebook/LinkBench/GraphStoreTestBase.java
@@ -67,10 +67,10 @@ public abstract class GraphStoreTestBase extends TestCase {
   }
 
   /** Get a new handle to the initialized store, wrapped in
-   * DummyLinkStore
+   * StatsDummyLinkStore
    * @return new handle to linkstore
    */
-  protected abstract DummyLinkStore getStoreHandle(boolean initialized)
+  protected abstract StatsDummyLinkStore getStoreHandle(boolean initialized)
                                     throws IOException, Exception;
 
   @Override
@@ -177,7 +177,7 @@ public abstract class GraphStoreTestBase extends TestCase {
       LinkStoreTestBase.serialLoad(rng, logger, props, getStoreHandle(false));
       serialLoadNodes(rng, logger, props, getStoreHandle(false));
 
-      DummyLinkStore reqStore = getStoreHandle(false);
+      StatsDummyLinkStore reqStore = getStoreHandle(false);
       LatencyStats latencyStats = new LatencyStats(1);
       RequestProgress tracker = new RequestProgress(logger, requests, timeLimit, 1, 10000);
 
@@ -237,7 +237,7 @@ public abstract class GraphStoreTestBase extends TestCase {
    * Delete all nodes in ID range specified
    */
   static void deleteNodeIDRange(String testDB, int type,
-      DummyLinkStore storeHandle,
+      StatsDummyLinkStore storeHandle,
       long startId, long idCount) throws Exception {
     for (long i = startId; i < startId + idCount; i++) {
       storeHandle.deleteNode(testDB, type, i);
@@ -245,7 +245,7 @@ public abstract class GraphStoreTestBase extends TestCase {
   }
 
   private void serialLoadNodes(Random rng, Logger logger, Properties props,
-      DummyLinkStore storeHandle) throws Exception {
+      StatsDummyLinkStore storeHandle) throws Exception {
     storeHandle.initialize(props, Phase.LOAD, 0);
     storeHandle.resetNodeStore(testDB, ConfigUtil.getLong(props,
                                                   Config.MIN_ID));

--- a/src/test/java/com/facebook/LinkBench/LinkStoreTestBase.java
+++ b/src/test/java/com/facebook/LinkBench/LinkStoreTestBase.java
@@ -87,10 +87,10 @@ public abstract class LinkStoreTestBase extends TestCase {
   }
 
   /** Get a new handle to the initialized store, wrapped in
-   * DummyLinkStore
+   * StatsDummyLinkStore
    * @return new handle to linkstore
    */
-  protected abstract DummyLinkStore getStoreHandle(boolean initialized)
+  protected abstract StatsDummyLinkStore getStoreHandle(boolean initialized)
                                     throws IOException, Exception;
 
   @Override
@@ -201,7 +201,7 @@ public abstract class LinkStoreTestBase extends TestCase {
   /** Simple test with multiple operations on single link */
   @Test
   public void testOneLink() throws IOException, Exception {
-    DummyLinkStore store = getStoreHandle(true);
+    StatsDummyLinkStore store = getStoreHandle(true);
 
     long id1 = 1123, id2 = 1124, ltype = 321;
     Link writtenLink = new Link(id1, ltype, id2,
@@ -267,7 +267,7 @@ public abstract class LinkStoreTestBase extends TestCase {
 
   @Test
   public void testMultipleLinks() throws Exception, IOException {
-    DummyLinkStore store = getStoreHandle(true);
+    StatsDummyLinkStore store = getStoreHandle(true);
     long ida = 5434, idb = 5435, idc = 9999, idd = 9998;
     long ltypea = 1, ltypeb = 2;
 
@@ -339,7 +339,7 @@ public abstract class LinkStoreTestBase extends TestCase {
    */
   @Test
   public void testMultiget() throws IOException, Exception {
-    DummyLinkStore store = getStoreHandle(true);
+    StatsDummyLinkStore store = getStoreHandle(true);
     long id1 = 99999999999L;
     Link a = new Link(id1, LinkStore.DEFAULT_LINK_TYPE, 42,
                       LinkStore.VISIBILITY_DEFAULT, new byte[0], 1,
@@ -369,7 +369,7 @@ public abstract class LinkStoreTestBase extends TestCase {
    */
   @Test
   public void testHiding() throws Exception {
-    DummyLinkStore store = getStoreHandle(true);
+    StatsDummyLinkStore store = getStoreHandle(true);
     Link l = new Link(1, 1, 1,
           LinkStore.VISIBILITY_HIDDEN, new byte[] {0x1}, 1,
           System.currentTimeMillis());
@@ -404,7 +404,7 @@ public abstract class LinkStoreTestBase extends TestCase {
     changed.data = new byte[] {'2', '2', '2'};
     changed.version = 1;
     changed.time = 2;
-    DummyLinkStore store = getStoreHandle(true);
+    StatsDummyLinkStore store = getStoreHandle(true);
 
     store.addLink(testDB, orig, true);
 
@@ -448,7 +448,7 @@ public abstract class LinkStoreTestBase extends TestCase {
 
   private void testAddThenUpdate(Link l, byte[] updateData) throws IOException,
       Exception {
-    DummyLinkStore ls = getStoreHandle(true);
+    StatsDummyLinkStore ls = getStoreHandle(true);
     ls.addLink(testDB, l, true);
 
     Link l2 = ls.getLink(testDB, 1, 1, 1);
@@ -527,7 +527,7 @@ public abstract class LinkStoreTestBase extends TestCase {
     fillLoadProps(props, startId, idCount, linksPerId);
 
     initStore(props);
-    DummyLinkStore store = getStoreHandle(false);
+    StatsDummyLinkStore store = getStoreHandle(false);
 
     try {
       Random rng = createRNG();
@@ -591,7 +591,7 @@ public abstract class LinkStoreTestBase extends TestCase {
 
       serialLoad(rng, logger, props, getStoreHandle(false));
 
-      DummyLinkStore reqStore = getStoreHandle(false);
+      StatsDummyLinkStore reqStore = getStoreHandle(false);
       LatencyStats latencyStats = new LatencyStats(1);
       RequestProgress tracker = new RequestProgress(logger, requests, timeLimit, 0, 1000);
 
@@ -654,7 +654,7 @@ public abstract class LinkStoreTestBase extends TestCase {
       serialLoad(rng, logger, props, getStoreHandle(false));
       RequestProgress tracker = new RequestProgress(logger, requests, timeLimit, 2, 1000);
 
-      DummyLinkStore reqStore = getStoreHandle(false);
+      StatsDummyLinkStore reqStore = getStoreHandle(false);
       LinkBenchRequest requester = new LinkBenchRequest(reqStore, null,
                       props, new LatencyStats(1), System.out, tracker,
                       rng, 0, 1);
@@ -713,7 +713,7 @@ public abstract class LinkStoreTestBase extends TestCase {
       serialLoad(rng, logger, props, getStoreHandle(false));
       RequestProgress tracker = new RequestProgress(logger, requests, timeLimit, 0, 1000);
 
-      DummyLinkStore reqStore = getStoreHandle(false);
+      StatsDummyLinkStore reqStore = getStoreHandle(false);
       reqStore.setRangeLimit(rangeLimit); // Small limit for testing
       LatencyStats latencyStats = new LatencyStats(1);
       LinkBenchRequest requester = new LinkBenchRequest(reqStore, null,
@@ -741,7 +741,7 @@ public abstract class LinkStoreTestBase extends TestCase {
     }
   }
 
-  private void checkExpectedList(DummyLinkStore store,
+  private void checkExpectedList(StatsDummyLinkStore store,
             long id1, long ltype, Link... expected) throws Exception {
     if (!store.isRealLinkStore()) return;
     assertEquals(expected.length, store.countLinks(testDB, id1, ltype));
@@ -769,7 +769,7 @@ public abstract class LinkStoreTestBase extends TestCase {
    * @throws Exception
    */
   static void serialLoad(Random rng, Logger logger, Properties props,
-      DummyLinkStore store) throws IOException, Exception {
+      StatsDummyLinkStore store) throws IOException, Exception {
     LatencyStats latencyStats = new LatencyStats(1);
 
     /* Load up queue with work */
@@ -800,7 +800,7 @@ public abstract class LinkStoreTestBase extends TestCase {
         + " in rows");
   }
 
-  private void validateLoadedData(Logger logger, DummyLinkStore wrappedStore,
+  private void validateLoadedData(Logger logger, StatsDummyLinkStore wrappedStore,
       long startId, long idCount, int linksPerId, long maxTimestamp)
                                                           throws Exception {
     for (long i = startId; i < startId + idCount; i++) {
@@ -832,7 +832,7 @@ public abstract class LinkStoreTestBase extends TestCase {
   }
 
   static void deleteIDRange(String testDB,
-        DummyLinkStore store, long startId, long idCount)
+        StatsDummyLinkStore store, long startId, long idCount)
       throws Exception {
     // attempt to delete data
     for (long i = startId; i < startId + idCount; i++) {

--- a/src/test/java/com/facebook/LinkBench/MemoryGraphStoreTest.java
+++ b/src/test/java/com/facebook/LinkBench/MemoryGraphStoreTest.java
@@ -27,8 +27,8 @@ public class MemoryGraphStoreTest extends GraphStoreTestBase {
   }
 
   @Override
-  protected DummyLinkStore getStoreHandle(boolean initialized) throws IOException, Exception {
-    return new DummyLinkStore(store.newHandle(), initialized);
+  protected StatsDummyLinkStore getStoreHandle(boolean initialized) throws IOException, Exception {
+    return new StatsDummyLinkStore(store.newHandle(), initialized);
   }
 
 }

--- a/src/test/java/com/facebook/LinkBench/MemoryLinkStoreTest.java
+++ b/src/test/java/com/facebook/LinkBench/MemoryLinkStoreTest.java
@@ -41,10 +41,10 @@ public class MemoryLinkStoreTest extends LinkStoreTestBase {
   }
 
   @Override
-  protected DummyLinkStore getStoreHandle(boolean initialized) {
+  protected StatsDummyLinkStore getStoreHandle(boolean initialized) {
     // Return a new memory link store handle. The underlying link store doesn't
     // need to be initialized, so just set wrapper to correct init status
-    return new DummyLinkStore(store.newHandle(), initialized);
+    return new StatsDummyLinkStore(store.newHandle(), initialized);
   }
 
 }

--- a/src/test/java/com/facebook/LinkBench/MemoryNodeStoreTest.java
+++ b/src/test/java/com/facebook/LinkBench/MemoryNodeStoreTest.java
@@ -28,7 +28,7 @@ public class MemoryNodeStoreTest extends NodeStoreTestBase {
 
   @Override
   protected NodeStore getNodeStoreHandle(boolean initialized) throws Exception, IOException {
-    return new DummyLinkStore(store.newHandle(), initialized);
+    return new StatsDummyLinkStore(store.newHandle(), initialized);
   }
 
 }

--- a/src/test/java/com/facebook/LinkBench/MySqlGraphStoreTest.java
+++ b/src/test/java/com/facebook/LinkBench/MySqlGraphStoreTest.java
@@ -65,8 +65,8 @@ public class MySqlGraphStoreTest extends GraphStoreTestBase {
 
 
   @Override
-  protected DummyLinkStore getStoreHandle(boolean initialize) throws IOException, Exception {
-    DummyLinkStore result = new DummyLinkStore(new LinkStoreMysql());
+  protected StatsDummyLinkStore getStoreHandle(boolean initialize) throws IOException, Exception {
+    StatsDummyLinkStore result = new StatsDummyLinkStore(new LinkStoreMysql());
     if (initialize) {
       result.initialize(props, Phase.REQUEST, 0);
     }

--- a/src/test/java/com/facebook/LinkBench/MySqlLinkStoreTest.java
+++ b/src/test/java/com/facebook/LinkBench/MySqlLinkStoreTest.java
@@ -71,8 +71,8 @@ public class MySqlLinkStoreTest extends LinkStoreTestBase {
 
 
   @Override
-  public DummyLinkStore getStoreHandle(boolean initialize) throws IOException, Exception {
-    DummyLinkStore result = new DummyLinkStore(new LinkStoreMysql());
+  public StatsDummyLinkStore getStoreHandle(boolean initialize) throws IOException, Exception {
+    StatsDummyLinkStore result = new StatsDummyLinkStore(new LinkStoreMysql());
     if (initialize) {
       result.initialize(currProps, Phase.REQUEST, 0);
     }

--- a/src/test/java/com/facebook/LinkBench/MySqlNodeStoreTest.java
+++ b/src/test/java/com/facebook/LinkBench/MySqlNodeStoreTest.java
@@ -46,7 +46,7 @@ public class MySqlNodeStoreTest extends NodeStoreTestBase {
 
   @Override
   protected NodeStore getNodeStoreHandle(boolean initialize) throws Exception, IOException {
-    DummyLinkStore result = new DummyLinkStore(new LinkStoreMysql());
+    StatsDummyLinkStore result = new StatsDummyLinkStore(new LinkStoreMysql());
     if (initialize) {
       result.initialize(currProps, Phase.REQUEST, 0);
     }

--- a/src/test/java/com/facebook/LinkBench/StatsDummyLinkStore.java
+++ b/src/test/java/com/facebook/LinkBench/StatsDummyLinkStore.java
@@ -19,30 +19,25 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
-import com.facebook.LinkBench.Link;
-import com.facebook.LinkBench.LinkCount;
-import com.facebook.LinkBench.LinkStore;
-import com.facebook.LinkBench.Phase;
-
 /**
  * Can either be used as a wrapper around an existing LinkStore instance that
  * logs operations, or as a dummy linkstore instance that does nothing
  *
  */
-public class DummyLinkStore extends GraphStore {
+public class StatsDummyLinkStore extends GraphStore {
 
   public LinkStore wrappedStore;
   public GraphStore wrappedGraphStore;
 
-  public DummyLinkStore() {
+  public StatsDummyLinkStore() {
     this(null);
   }
 
-  public DummyLinkStore(LinkStore wrappedStore) {
+  public StatsDummyLinkStore(LinkStore wrappedStore) {
     this(wrappedStore, false);
   }
 
-  public DummyLinkStore(LinkStore wrappedStore, boolean alreadyInitialized) {
+  public StatsDummyLinkStore(LinkStore wrappedStore, boolean alreadyInitialized) {
     this.wrappedStore = wrappedStore;
     if (wrappedStore instanceof GraphStore) {
       wrappedGraphStore = (GraphStore) wrappedStore;

--- a/src/test/java/com/facebook/LinkBench/StatsDummyLinkStoreTest.java
+++ b/src/test/java/com/facebook/LinkBench/StatsDummyLinkStoreTest.java
@@ -18,7 +18,7 @@ package com.facebook.LinkBench;
 import java.io.IOException;
 import java.util.Properties;
 
-public class DummyLinkStoreTest extends LinkStoreTestBase {
+public class StatsDummyLinkStoreTest extends LinkStoreTestBase {
 
   private Properties props;
 
@@ -29,9 +29,9 @@ public class DummyLinkStoreTest extends LinkStoreTestBase {
   }
 
   @Override
-  protected DummyLinkStore getStoreHandle(boolean initialized)
+  protected StatsDummyLinkStore getStoreHandle(boolean initialized)
                                   throws IOException, Exception {
-    DummyLinkStore store = new DummyLinkStore();
+    StatsDummyLinkStore store = new StatsDummyLinkStore();
     if (initialized) {
       store.initialize(props, Phase.REQUEST, 0);
     }


### PR DESCRIPTION
Slightly more descriptive.

Thought a rename along these sorts of lines is in order. Just "Dummy" is a bit misleading, as it's used in all the tests mainly to record stats, not as a mock store.
