### PR TITLE
Make it faster for MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ Run the following commands in the MySQL console:
       `data` varchar(255) NOT NULL DEFAULT '',
       `time` bigint(20) unsigned NOT NULL DEFAULT '0',
       `version` int(11) unsigned NOT NULL DEFAULT '0',
-      PRIMARY KEY (`id1`,`id2`,`link_type`),
-      KEY `id1_type` (`id1`,`link_type`,`visibility`,`time`,`version`,`data`)
+      PRIMARY KEY (link_type, `id1`,`id2`),
+      KEY `id1_type` (`id1`,`link_type`,`visibility`,`time`,`id2`,`version`,`data`)
     ) ENGINE=InnoDB DEFAULT CHARSET=latin1 PARTITION BY key(id1) PARTITIONS 16;
 
     CREATE TABLE `counttable` (


### PR DESCRIPTION
Use 2 connections per client -- read-write, read-only. This avoids the need 
to send "commit" for queries. This also lets InnoDB use its fast-path
for read-only transactions (SELECT when in auto-commit mode). And it reduces
the number of statements that are run (fewer COMMIT calls are made).

Add FORCE_INDEX hint on link range query to keep InnoDB from doing IO
to estimate selectivity on the wrong index.

Update indexes for linktable in README.md. These options reduce disk reads
during IO-bound linkbench.

With these changes I almost doubled QPS.
