### PR TITLE
Fixing id1_type index instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ After loading you should revert the changes:
     set global innodb_flush_log_at_trx_commit = 1;
     set global sync_binlog = 1;
     alter table linktable add key `id1_type`
-      (`id1`,`link_type`,`visibility`,`time`,`version`,`data`);
+      (`id1`,`link_type`,`visibility`,`time`,`id2`,`version`,`data`);
 
 Request Phase
 -------------


### PR DESCRIPTION
Without adding id2, range scans not including id2 column do not use covering index, if storage
engines do not include primary key values within secondary index (i.e. MyISAM).
