### PR TITLE
Update LinkStoreMysql.java

### DIFF
--- a/src/main/java/com/facebook/LinkBench/LinkStoreMysql.java
+++ b/src/main/java/com/facebook/LinkBench/LinkStoreMysql.java
@@ -145,6 +145,7 @@ public class LinkStoreMysql extends GraphStore {
     Class.forName("com.mysql.jdbc.Driver").newInstance();
 
     jdbcUrl += "?elideSetAutoCommits=true" +
+               "&useSSL=false" +
                "&useLocalTransactionState=true" +
                "&allowMultiQueries=true" +
                "&useLocalSessionState=true" +


### PR DESCRIPTION
Allow usage with later mysql versions without needing to configure SSL:
"&useSSL=false"
