### PR TITLE
Add thread level to csv output.

### DIFF
--- a/src/main/java/com/facebook/LinkBench/stats/LatencyStats.java
+++ b/src/main/java/com/facebook/LinkBench/stats/LatencyStats.java
@@ -173,7 +173,8 @@ public class LatencyStats {
                      " p95 = " + percentileString(type, 95)  + "ms " +
                      " p99 = " + percentileString(type, 99)  + "ms " +
                      " max = " + df.format(getMax(type)) + "ms " +
-                     " mean = " + df.format(getMean(type))+ "ms");
+                     " mean = " + df.format(getMean(type))+ "ms" +
+                     " threads = " + maxThreads);
     }
   }
 
@@ -190,7 +191,7 @@ public class LatencyStats {
       for (int percentile: percentiles) {
         out.print(String.format(",p%d_low,p%d_high", percentile, percentile));
       }
-      out.print(",max,mean");
+      out.print(",max,mean,threads");
       out.println();
     }
 
@@ -218,6 +219,8 @@ public class LatencyStats {
       out.print(df.format(getMax(op)));
       out.print(",");
       out.print(df.format(getMean(op)));
+      out.print(",");
+      out.print("maxThreads");
       out.println();
     }
   }


### PR DESCRIPTION
Hello,

I am an infrastructure engineer on the performance team at MongoDB and we are using Linkbench as part of our performance testing. After a Linkbench task is run, we need to parse the results and the thread levels used. It would be cleaner to have the thread levels in the csv file along with the results. I think this would be helpful to many users of Linkbench, and at the very least won't hurt them as it is backwards compatible.

Thanks,
Julian